### PR TITLE
Added Prefix string extraction and command-line generation

### DIFF
--- a/src/CLIParser/ArgumentMetadata.cs
+++ b/src/CLIParser/ArgumentMetadata.cs
@@ -105,6 +105,10 @@ namespace MASES.CLIParser
         /// </summary>
         string CustomPrefix { get; set; }
         /// <summary>
+        /// The string representing the actual prefix from configuration
+        /// </summary>
+        string PrefixInUse { get; }
+        /// <summary>
         /// Argument name
         /// </summary>
         string Name { get; set; }
@@ -261,6 +265,8 @@ namespace MASES.CLIParser
         /// <inheritdoc/>
         public virtual string CustomPrefix { get; set; }
         /// <inheritdoc/>
+        public string PrefixInUse => Prefix?.Prefix(CustomPrefix);
+        /// <inheritdoc/>
         public virtual string Name { get; set; }
         /// <inheritdoc/>
         public virtual string ShortName { get; set; }
@@ -373,7 +379,7 @@ namespace MASES.CLIParser
             Default = default(T);
             DataType = typeof(T);
             IsEnum = DataType.IsEnum;
-            foreach (var flagattrib in DataType.CustomAttributes)
+            foreach (var _ in DataType.CustomAttributes)
             {
                 IsFlag = true; break;
             }
@@ -383,20 +389,7 @@ namespace MASES.CLIParser
 
         string IArgumentMetadataHelper.GetPrefix()
         {
-            switch (Prefix)
-            {
-                case ArgumentPrefix.Dash:
-                    return InternalConst.ArgumentPrefix.Dash;
-                case ArgumentPrefix.DoubleDash:
-                    return InternalConst.ArgumentPrefix.DoubleDash;
-                case ArgumentPrefix.Slash:
-                    return InternalConst.ArgumentPrefix.Slash;
-                case ArgumentPrefix.Custom:
-                    return CustomPrefix;
-                case ArgumentPrefix.None:
-                default:
-                    return string.Empty;
-            }
+            return PrefixInUse;
         }
 
         Parser IArgumentMetadataHelper.Parser { get; set; }

--- a/src/CLIParser/CLIParser.cs
+++ b/src/CLIParser/CLIParser.cs
@@ -34,6 +34,29 @@ namespace MASES.CLIParser
     public static class ParserExtension
     {
         /// <summary>
+        /// Convert an <see cref="ArgumentPrefix"/> to the equivalent <see cref="string"/> representation
+        /// </summary>
+        /// <param name="prefix">The <see cref="ArgumentPrefix"/> to convert in string</param>
+        /// <param name="customPrefix">The custom prefix associated to <paramref name="prefix"/> with a value of <see cref="ArgumentPrefix.Custom"/></param>
+        public static string Prefix(this ArgumentPrefix prefix, string customPrefix = null)
+        {
+            switch (prefix)
+            {
+                case ArgumentPrefix.Dash:
+                    return InternalConst.ArgumentPrefix.Dash;
+                case ArgumentPrefix.DoubleDash:
+                    return InternalConst.ArgumentPrefix.DoubleDash;
+                case ArgumentPrefix.Slash:
+                    return InternalConst.ArgumentPrefix.Slash;
+                case ArgumentPrefix.Custom:
+                    return customPrefix;
+                case ArgumentPrefix.None:
+                default:
+                    return string.Empty;
+            }
+        }
+
+        /// <summary>
         /// Adds an <see cref="IArgumentMetadata"/>
         /// </summary>
         /// <param name="metadatas">The <see cref="IArgumentMetadata"/> to add</param>
@@ -239,7 +262,10 @@ namespace MASES.CLIParser
             DefaultIsCaseInvariant = true;
             DefaultDescriptionPadding = 30;
         }
-
+        /// <summary>
+        /// The string representing the actual prefix from configuration
+        /// </summary>
+        public string PrefixInUse { get { return DefaultPrefix.Prefix(DefaultCustomPrefix); } }
         /// <summary>
         /// Default value of identifier used when an argument represent a file containing the arguments
         /// </summary>

--- a/src/CLIParser/CLIParser.cs
+++ b/src/CLIParser/CLIParser.cs
@@ -58,7 +58,7 @@ namespace MASES.CLIParser
         /// <summary>
         /// Creates the command line switch associated to the switch with <paramref name="name"/> and <paramref name="value"/>
         /// </summary>
-        /// <param name="args">An ensemble of <see cref="IArgumentMetadata"/> to with all possible arguments</param>
+        /// <param name="metadatas">An ensemble of <see cref="IArgumentMetadata"/> with all possible arguments</param>
         /// <param name="name">The command-line switch name</param>
         /// <param name="values">The value(s) to use. Multiple value can be used in case of argument reports <see cref="IArgumentMetadata.IsMultiValue"/> as <see langword="true"/></param>
         /// <returns>The string equivalent for command-line</returns>

--- a/src/CLIParser/CLIParser.csproj
+++ b/src/CLIParser/CLIParser.csproj
@@ -14,7 +14,7 @@
 		<TargetFrameworks>netstandard2.0</TargetFrameworks>
 		<OutputPath>..\..\bin\</OutputPath>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 		<PackageProjectUrl>https://github.com/masesgroup/CLIParser/</PackageProjectUrl>
 		<PackageIconUrl>https://raw.githubusercontent.com/masesgroup/masesgroup.github.io/master/assets/images/mases_logo_short.png</PackageIconUrl>
 		<RepositoryUrl>https://github.com/masesgroup/CLIParser</RepositoryUrl>

--- a/src/CLIParser/CLIParser.csproj
+++ b/src/CLIParser/CLIParser.csproj
@@ -8,7 +8,7 @@
 		<Owners>MASES s.r.l.</Owners>
 		<Authors>MASES s.r.l.</Authors>
 		<Company>MASES s.r.l.</Company>
-		<Version>3.0.0.0</Version>
+		<Version>3.1.0.0</Version>
 		<Product>CLIParser</Product>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<TargetFrameworks>netstandard2.0</TargetFrameworks>

--- a/tests/CLIParserTest/CLIParserTest.csproj
+++ b/tests/CLIParserTest/CLIParserTest.csproj
@@ -9,7 +9,7 @@
     <Copyright>Copyright ©  MASES s.r.l. 2022</Copyright>
     <Authors>MASES s.r.l.</Authors>
     <Company>MASES s.r.l.</Company>
-    <Version>3.0.0.0</Version>
+    <Version>3.1.0.0</Version>
     <TargetFrameworks>net461;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <OutputPath>..\..\bin\</OutputPath>
   </PropertyGroup>


### PR DESCRIPTION
## Description
Added useful methods and property to extract actual string value related to the prefix string associated to a command-line switch or create the equivalent command-line for a specific argument.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closed #19 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not tested

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
